### PR TITLE
Fix the output format issue when there are multiple sentences in the translated text.

### DIFF
--- a/googletranslate/__init__.py
+++ b/googletranslate/__init__.py
@@ -278,9 +278,13 @@ class Translator(object):
             return TranslatedString("")
         self._last_data = raw
         
-        if isinstance(raw, str):
-            return TranslatedString(raw)
-        return TranslatedString(*raw)
+        if not isinstance(raw, str):
+            raw = ''.join(raw)
+       
+        if '<b>' in raw:
+            raw = ''.join(re.findall(r'<b>(.*?)</b>', raw))
+
+        return TranslatedString(raw)
         
 
     def _calc_token(self, text):


### PR DESCRIPTION
There is a formatting issue with the output when there are multiple sentences in the translated text. For example:
```Python
from googletranslate import translate

text = 'The sun slowly rises over the horizon, casting a warm glow on the world below. The birds begin to chirp, their songs filling the air with a sweet melody. '

print(translate(text, dest='zh', src='en'))
```
The above code will output:
```
<i>The sun slowly rises over the horizon, casting a warm glow on the world below.</i><b>太阳在地平线上慢慢升起，在下面的世界上
散发出温暖的光芒。</b> <i>The birds begin to chirp, their songs filling the air with a sweet melody.</i><b>鸟儿开始鸣叫，他们的
歌曲充满了甜美的旋律。</b>
```
This pull request extracts the content within all `<b>` tags and concatenates them into a single string.