### PR TITLE
Add ability to change API params  value

### DIFF
--- a/googletranslate/__init__.py
+++ b/googletranslate/__init__.py
@@ -180,8 +180,9 @@ def translate(
     text,
     dest,
     src="auto",
+    **kw,
 ):
-    return Translator(dest, src).translate(text)
+    return Translator(dest, src).translate(text, kw)
 
 
 class TranslatedString(str):
@@ -248,14 +249,14 @@ class Translator(object):
         self._last_request = self._last_response.request
         return r
 
-    def translate(self, text: str):
+    def translate(self, text: str, kw: dict):
         """translates  <text> to configured destination_language"""
         tk = self._calc_token(text)
         url = self._api_url.format("/translate_a/t")
 
         params = {
             "anno": "3",
-            "client": "t",
+            "client": kw.get("client", "t"),
             "format": "html",
             "v": 1.0,
             "key": None,


### PR DESCRIPTION
Hey man, I've been following your repos for a while they are genuinely impressive. Great work!

Recently, I've been working with translating Japanese text to English using your library. While it's been immensely useful, I felt the translation results were slightly off compared to when I translate pages directly in the browser.

Intrigued by this, I did a bit of digging and found a disparity in the 'client' parameter value in the request made to Google. Specifically, I noticed that my browser was passing { "client": "te_lib" } while your library passes { "client": "t" }.

I did some experimentation and swapped these values around. From my testing, it seems like "te_lib" gives more accurate results for my use case. Have you come across anything like this before with this parameter? It's possible that the current value might be a little outdated? I put together this PR to allow for customization of this param. Let me know if you think a different approach would be better. ([Maybe this PR could even close out this lingering issue](https://github.com/ultrafunkamsterdam/googletranslate/issues/8)).

Looking forward to your thoughts. Cheers!

Japanese Source (Browser)
<img width="810" alt="Screen Shot 2023-05-29 at 3 20 29 PM" src="https://github.com/ultrafunkamsterdam/googletranslate/assets/5459666/e45ee089-2876-45e2-bab5-88d3201beabe">

English Translation (Browser)
<img width="885" alt="Screen Shot 2023-05-29 at 3 13 44 PM" src="https://github.com/ultrafunkamsterdam/googletranslate/assets/5459666/7ca4733a-6c22-40ee-a4a8-487eab8650e3">

English Translation (client set to "t" (default))
<img width="1029" alt="Screen Shot 2023-05-29 at 3 21 24 PM" src="https://github.com/ultrafunkamsterdam/googletranslate/assets/5459666/d7e95488-8049-40a3-b296-d10fd6ff59c1">

English Translation (client set to "te_lib")
<img width="1017" alt="Screen Shot 2023-05-29 at 3 21 45 PM" src="https://github.com/ultrafunkamsterdam/googletranslate/assets/5459666/c5fbf93d-b758-4ba1-93c9-8fd2c2851898">

URL for reference: https://www.athome.co.jp/kodate/6978282056/?DOWN=1&BKLISTID=001LPC&sref=list_simple
